### PR TITLE
Downgrade Node.js version to 24.6.0 in tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs 24.8.0
+nodejs 24.6.0


### PR DESCRIPTION
- Updated .tool-versions file to use Node.js 24.6.0 instead of 24.8.0.
- Fixes npm compatibility issue causing missing executable error during local builds.