### PR TITLE
Add EmbeddedApp component and routing for Application Hub

### DIFF
--- a/oobe/src/App.tsx
+++ b/oobe/src/App.tsx
@@ -1,5 +1,7 @@
 import Sidebar from "./components/Sidebar";
 import "./App.css";
+import EmbeddedApp from "./components/EmbeddedApp";
+import { Routes, Route } from "react-router-dom";
 
 function App() {
   return (
@@ -8,7 +10,14 @@ function App() {
         <Sidebar />
       </aside>
       <section className="flex-grow-1 d-flex flex-column overflow-auto">
-        <main className="flex-grow-1 p-3 bg-light"></main>
+        <main className="flex-grow-1 p-3 bg-light">
+          <Routes>
+            <Route
+              path="/hub"
+              element={<EmbeddedApp url={"https://apphub.seco.com/"} />}
+            />
+          </Routes>
+        </main>
       </section>
     </div>
   );

--- a/oobe/src/components/EmbeddedApp.tsx
+++ b/oobe/src/components/EmbeddedApp.tsx
@@ -1,0 +1,13 @@
+type EmbeddedAppProps = {
+  url: string;
+};
+
+const EmbeddedApp = ({ url }: EmbeddedAppProps) => {
+  return (
+    <div className="hub-main">
+      <iframe src={url} title="SECO Application Hub"></iframe>
+    </div>
+  );
+};
+
+export default EmbeddedApp;


### PR DESCRIPTION
This pull request introduces a component to embed external applications via iframe and sets up routing to display the SECO Application Hub within the main layout. Enhances integration with external services for a seamless user experience.

Closes #10