### PR TITLE
Add routing for Developer Center

### DIFF
--- a/oobe/src/App.tsx
+++ b/oobe/src/App.tsx
@@ -16,6 +16,10 @@ function App() {
               path="/hub"
               element={<EmbeddedApp url={"https://apphub.seco.com/"} />}
             />
+            <Route
+              path="/developer"
+              element={<EmbeddedApp url={"https://developer.seco.com/"} />}
+            />
           </Routes>
         </main>
       </section>


### PR DESCRIPTION
This commit sets up routing to display the SECO  Developer Center within the main layout.
 
Closes #11