### PR TITLE
Add "Connect to Clea" page and sidebar navigation

### DIFF
--- a/oobe/src/App.tsx
+++ b/oobe/src/App.tsx
@@ -30,6 +30,17 @@ function App() {
                 />
               }
             />
+            <Route
+              path="/connect"
+              element={
+                <EmbeddedApp
+                  url={
+                    "https://developer.seco.com/clea-os/version-kirkstone_1-10-00/get_started/requirements"
+                  }
+                  title="Connect to Clea"
+                />
+              }
+            />
           </Routes>
         </main>
       </section>

--- a/oobe/src/components/Sidebar.tsx
+++ b/oobe/src/components/Sidebar.tsx
@@ -44,6 +44,12 @@ const Sidebar = () => {
             defaultMessage="Developer Center"
           />
         </NavLink>
+        <NavLink to="/connect" className="nav-link">
+          <FormattedMessage
+            id="components.Sidebar.connectToClea"
+            defaultMessage="Connect to Clea"
+          />
+        </NavLink>
       </Nav>
       <hr className="border-top border-secondary w-100" />
       <Container fluid className="sidebar-bottom px-3 py-2">

--- a/oobe/src/i18n/langs/en.json
+++ b/oobe/src/i18n/langs/en.json
@@ -8,6 +8,9 @@
   "components.Sidebar.developerCenter": {
     "defaultMessage": "Developer Center"
   },
+  "components.Sidebar.connectToClea": {
+    "defaultMessage": "Connect to Clea"
+  },
   "components.Sidebar.exit": {
     "defaultMessage": "Exit"
   }

--- a/oobe/src/i18n/langs/it.json
+++ b/oobe/src/i18n/langs/it.json
@@ -8,6 +8,9 @@
   "components.Sidebar.developerCenter": {
     "defaultMessage": "Developer Center"
   },
+  "components.Sidebar.connectToClea": {
+    "defaultMessage": "Connect to Clea"
+  },
   "components.Sidebar.exit": {
     "defaultMessage": "Exit"
   }


### PR DESCRIPTION
This pull request introduces a new sidebar link and route for connecting to Clea, embedding the relevant documentation page within the app and updates translation files.

Screenshot:
<img width="1865" height="932" alt="Screenshot 2025-10-15 at 14-59-07 Out of the Box Experience" src="https://github.com/user-attachments/assets/9134e0eb-0acb-4f54-8b3f-20bcbbf6e5e9" />

    
Closes #12
