### PR TITLE
Remove App Hub and Dev Hub button from sidebar

### DIFF
--- a/oobe/src/App.tsx
+++ b/oobe/src/App.tsx
@@ -86,24 +86,6 @@ function App() {
               element={<SmartClinical apiClient={apiClient} />}
             />
             <Route
-              path="/hub"
-              element={
-                <EmbeddedApp
-                  url={"https://apphub.seco.com/"}
-                  title="Application Hub"
-                />
-              }
-            />
-            <Route
-              path="/developer"
-              element={
-                <EmbeddedApp
-                  url={"https://developer.seco.com/"}
-                  title="Developer Center"
-                />
-              }
-            />
-            <Route
               path="/connect"
               element={
                 <EmbeddedApp

--- a/oobe/src/components/Sidebar.tsx
+++ b/oobe/src/components/Sidebar.tsx
@@ -1,20 +1,11 @@
 import { useState } from "react";
-import { NavLink, useNavigate } from "react-router-dom";
-import {
-  Nav,
-  Container,
-  Row,
-  Col,
-  Button,
-  Image,
-  Collapse,
-} from "react-bootstrap";
+import { NavLink } from "react-router-dom";
+import { Nav, Container, Row, Col, Image, Collapse } from "react-bootstrap";
 import { FormattedMessage } from "react-intl";
 import "./Sidebar.scss";
 import { logo } from "../assets/images";
 
 const Sidebar = () => {
-  const navigate = useNavigate();
   const [open, setOpen] = useState(false);
 
   return (
@@ -70,38 +61,6 @@ const Sidebar = () => {
                 />
               </NavLink>
             </Nav>
-
-            <Container fluid className="sidebar-bottom mt-4">
-              <Row className="mb-1">
-                <hr className="text-light" />
-              </Row>
-              <Row className="w-100">
-                <Col>
-                  <Button
-                    variant="light"
-                    className="px-3 mx-1 w-100"
-                    onClick={() => {
-                      navigate("/hub");
-                      setOpen(false);
-                    }}
-                  >
-                    App Hub
-                  </Button>
-                </Col>
-                <Col>
-                  <Button
-                    variant="outline-light"
-                    className="px-2 mx-1 w-100"
-                    onClick={() => {
-                      navigate("/developer");
-                      setOpen(false);
-                    }}
-                  >
-                    Dev Center
-                  </Button>
-                </Col>
-              </Row>
-            </Container>
           </div>
         </Collapse>
       </div>


### PR DESCRIPTION
Clean up sidebar by removing the App Hub and Dev hub navigation buttons


<img width="1833" height="945" alt="image" src="https://github.com/user-attachments/assets/9c5c606b-9cab-4a08-8830-046471d33042" />
