### PR TITLE
Update card text color to white

### DIFF
--- a/oobe/src/components/DeviceDetails.scss
+++ b/oobe/src/components/DeviceDetails.scss
@@ -34,7 +34,7 @@
     font-family: "Poppins", sans-serif;
     font-size: 0.875rem;
     font-weight: 400;
-    color: #585555;
+    color: white;
     text-align: right;
     padding-right: 0;
 

--- a/oobe/src/components/LogCard.tsx
+++ b/oobe/src/components/LogCard.tsx
@@ -36,7 +36,7 @@ const SystemUsageLog = ({ usageLogs }: SystemUsageLogProps) => {
                         className="d-flex align-items-center gap-2"
                       >
                         <span className="dot dot-cpu" />
-                        <small className="text-secondary">
+                        <small>
                           <FormattedMessage
                             id="components.SystemUsageLog.cpu"
                             defaultMessage={"CPU"}
@@ -50,7 +50,7 @@ const SystemUsageLog = ({ usageLogs }: SystemUsageLogProps) => {
                         className="d-flex align-items-center gap-2"
                       >
                         <span className="dot dot-ram" />
-                        <small className="text-secondary">
+                        <small>
                           <FormattedMessage
                             id="components.SystemUsageLog.ram"
                             defaultMessage={"RAM"}
@@ -64,7 +64,7 @@ const SystemUsageLog = ({ usageLogs }: SystemUsageLogProps) => {
               </Col>
 
               <Col xs={4} className="text-end">
-                <small className="text-secondary">
+                <small>
                   {log.date}, {log.time}
                 </small>
               </Col>


### PR DESCRIPTION
Set text color to white on log and device cards for better contrast

Screen:
<img width="1840" height="958" alt="image" src="https://github.com/user-attachments/assets/4f8cb892-5dca-4de8-b2b8-b0369a39b9f7" />
