### PR TITLE
Fix hospitalizationReason field naming

### DIFF
--- a/oobe-apps/medical-app/src/api/AstarteAPIClient.ts
+++ b/oobe-apps/medical-app/src/api/AstarteAPIClient.ts
@@ -51,7 +51,7 @@ class AstarteAPIClient {
             height: response.data.data.height,
             phisician: response.data.data.phisician,
             weight: response.data.data.weight,
-            hospitalization_reason: response.data.data.hospitalization_reason,
+            hospitalizationReason: response.data.data.hospitalizationReason,
           }) as PatientOverviewData,
       )
       .catch((error) => {

--- a/oobe-apps/medical-app/src/components/PatientOverview.tsx
+++ b/oobe-apps/medical-app/src/components/PatientOverview.tsx
@@ -52,7 +52,7 @@ const PatientOverview = ({ data }: PatientOverviewProps) => {
               <Form.Control
                 as="textarea"
                 rows={4}
-                value={data?.hospitalization_reason || ""}
+                value={data?.hospitalizationReason || ""}
                 readOnly
               />
             </Form.Group>

--- a/oobe-apps/medical-app/src/types/index.tsx
+++ b/oobe-apps/medical-app/src/types/index.tsx
@@ -5,5 +5,5 @@ export type PatientOverviewData = {
   height: number;
   phisician: string;
   weight: number;
-  hospitalization_reason: string;
+  hospitalizationReason: string;
 };


### PR DESCRIPTION
- Renamed `hospitalization_reason` to `hospitalizationReason` in `PatientOverviewData`
- Aligned field naming with camelCase convention used across the codebase