### PR TITLE
SmartClinical: replace DataStreamChart with uPlot-based ECGChart

### DIFF
--- a/oobe/package-lock.json
+++ b/oobe/package-lock.json
@@ -23,7 +23,8 @@
         "react-dom": "^19.1.1",
         "react-intl": "^7.1.14",
         "react-leaflet": "^5.0.0-rc.2",
-        "react-router-dom": "^7.9.4"
+        "react-router-dom": "^7.9.4",
+        "uplot": "^1.6.32"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -5320,6 +5321,11 @@
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
       }
+    },
+    "node_modules/uplot": {
+      "version": "1.6.32",
+      "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.32.tgz",
+      "integrity": "sha512-KIMVnG68zvu5XXUbC4LQEPnhwOxBuLyW1AHtpm6IKTXImkbLgkMy+jabjLgSLMasNuGGzQm/ep3tOkyTxpiQIw=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/oobe/package.json
+++ b/oobe/package.json
@@ -29,7 +29,8 @@
     "react-dom": "^19.1.1",
     "react-intl": "^7.1.14",
     "react-leaflet": "^5.0.0-rc.2",
-    "react-router-dom": "^7.9.4"
+    "react-router-dom": "^7.9.4",
+    "uplot": "^1.6.32"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/oobe/src/components/ECGChart.scss
+++ b/oobe/src/components/ECGChart.scss
@@ -1,0 +1,33 @@
+.ecg-chart-card {
+  width: 100%;
+  margin: 0 auto;
+  height: 100%;
+  min-height: 200px;
+  background-color: #131313 !important;
+
+  .card-header {
+    border-bottom: none;
+  }
+
+  .usage-section {
+    position: relative;
+    
+    .uplot-container {
+        width: 100%;
+        
+        .uplot {
+             /* uPlot canvas here */
+        }
+    }
+
+    .dot {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      display: inline-block;
+      &.dot-default {
+          background-color: #00ff00; /* Default if not overridden */
+      }
+    }
+  }
+}

--- a/oobe/src/components/ECGChart.tsx
+++ b/oobe/src/components/ECGChart.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useRef } from "react";
+import uPlot from "uplot";
+import "uplot/dist/uPlot.min.css";
+import { Card, Row, Col } from "react-bootstrap";
+import "./ECGChart.scss";
+
+interface ECGDataPoint {
+  x: number; // timestamp
+  y: number; // value
+}
+
+interface ECGChartProps {
+  data: ECGDataPoint[];
+  title: string;
+  subtitle: string;
+  color?: string;
+}
+
+const ECGChart = ({
+  data,
+  title,
+  subtitle,
+  color = "#00ff00",
+}: ECGChartProps) => {
+  const chartRef = useRef<HTMLDivElement>(null);
+  const uPlotRef = useRef<uPlot | null>(null);
+
+  // Initialize uPlot
+  useEffect(() => {
+    if (!chartRef.current) return;
+
+    const opts: uPlot.Options = {
+      title: "",
+      width: chartRef.current.clientWidth,
+      height: 150,
+      series: [
+        {}, // x-series
+        {
+          // y-series
+          stroke: color,
+          width: 2,
+          points: { show: false },
+        },
+      ],
+      axes: [
+        {
+          // x-axis
+          show: true,
+          grid: { show: true, stroke: "#333", width: 1 },
+          stroke: "#fff",
+          values: (self, ticks) => {
+             return ticks.map(t => new Date(t).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" }));
+          }
+        },
+        {
+          // y-axis
+          show: false, // hide y axis
+          grid: { show: false },
+        },
+      ],
+      legend: { show: false },
+      cursor: {
+        drag: { x: false, y: false },
+        points: { size: 7 },
+      },
+      scales: {
+        x: {
+          time: false,
+        },
+      },
+    };
+
+    const chartData = [
+      data.map((d) => d.x),
+      data.map((d) => d.y),
+    ] as [number[], number[]];
+
+    const u = new uPlot(opts, chartData, chartRef.current);
+    uPlotRef.current = u;
+
+    // Resize observer to handle window resize
+    const resizeObserver = new ResizeObserver((entries) => {
+      if (!uPlotRef.current) return;
+      for (const entry of entries) {
+        if (entry.contentRect) {
+            uPlotRef.current.setSize({
+                width: entry.contentRect.width,
+                height: 150
+            });
+        }
+      }
+    });
+    resizeObserver.observe(chartRef.current);
+
+    return () => {
+      u.destroy();
+      resizeObserver.disconnect();
+      uPlotRef.current = null;
+    };
+    // We only want to initialize once or when color changes significantly (which it shouldn't)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [color]);
+
+  // Update data
+  useEffect(() => {
+    if (!uPlotRef.current) return;
+    
+    // Transform data for uPlot
+    // uPlot expects [series1_data, series2_data, ...]
+    // where series1_data is x-values
+    const xValues = data.map((d) => d.x);
+    const yValues = data.map((d) => d.y);
+
+    if (xValues.length > 0) {
+        // Update data
+        uPlotRef.current.setData([xValues, yValues]);
+    }
+  }, [data]);
+
+  return (
+    <Card className="ecg-chart-card rounded-5 border-secondary border-2">
+      <Card.Body className="d-flex flex-column">
+        <Card.Header className="d-flex justify-content-between align-items-center mb-1 bg-transparent border-0">
+          <Card.Title className="fw-bold fs-5 mb-1 ms-1 text-white">
+            {title}
+          </Card.Title>
+        </Card.Header>
+
+        <div className="usage-section d-flex flex-column h-100">
+          <Row className="subtitle-container align-items-center justify-content-between mb-2">
+            <Col xs="auto" className="d-flex align-items-center ms-3 gap-3">
+               <div className="dot dot-default" style={{backgroundColor: color}} />
+              <span className="fw-semibold fs-1 text-white">
+                {subtitle || "Loading..."}
+              </span>
+            </Col>
+          </Row>
+          <div ref={chartRef} className="uplot-container flex-grow-1" />
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default ECGChart;

--- a/oobe/src/pages/SmartClinical.tsx
+++ b/oobe/src/pages/SmartClinical.tsx
@@ -4,7 +4,7 @@ import { Button, Col, Container, Row, Image } from "react-bootstrap";
 import { NavLink } from "react-router-dom";
 import { expand, logo, person } from "../assets/images";
 import "./SmartClinical.scss";
-import DataStreamChart from "../components/DataStreamChart";
+import ECGChart from "../components/ECGChart";
 import { useEffect, useState } from "react";
 import type { APIClient, SmartClinicalRecordUpdate } from "../api/APIClient";
 import LaboratoryReportModal from "../components/BloodCountModal";
@@ -252,13 +252,13 @@ const SmartClinical = ({ apiClient }: SmartClinicalProps) => {
           <Col md={8}>
             <Row className="g-3 mb-3">
               <Col xs={12} md={12} lg={12} className="d-flex">
-                <DataStreamChart
-                  chartType="line"
-                  leftTitle={"ECG Recording"}
-                  leftSubtitle={
+                <ECGChart
+                  title={"ECG Recording"}
+                  subtitle={
                     realTimeBpmCurrent.toFixed(1).toString() + " bpm"
                   }
-                  chartData1={ecgCurrent}
+                  data={ecgCurrent}
+                  color="#165BAA"
                 />
               </Col>
             </Row>


### PR DESCRIPTION
The previous `DataStreamChart` component was causing severe performance issues in some platforms (e.g. D18) due to heavy SVG rendering overhead during high-frequency updates.

This commit introduces `ECGChart`, a new component built on top of `uPlot`. `uPlot` uses the HTML5 Canvas API for rendering.