### PR TITLE
Fix crash when no data is returned

### DIFF
--- a/oobe-apps/smart-building-app/src/App.tsx
+++ b/oobe-apps/smart-building-app/src/App.tsx
@@ -70,6 +70,7 @@ const App = ({ astarteUrl, realm, deviceId, token }: AppProps) => {
       .then((results) => {
         const combined: CameraHistoryData[] = results
           .flat()
+          .filter((item): item is CameraHistoryData => item != null)
           .sort(
             (a, b) =>
               new Date(b.datetime).getTime() - new Date(a.datetime).getTime(),
@@ -172,7 +173,9 @@ const App = ({ astarteUrl, realm, deviceId, token }: AppProps) => {
         ),
       )
       .then((results) => {
-        const combined: CameraHistoryData[] = results.flat();
+        const combined: CameraHistoryData[] = results
+          .flat()
+          .filter((item): item is CameraHistoryData => item != null);
         const stats = calculateWeeklyStats(combined, intl);
         setWeeklyStats(stats);
       })


### PR DESCRIPTION
Fix crash when no data is available by filtering undefined history items