### PR TITLE
[FIX] fix lock resolution

### DIFF
--- a/oobe/src/components/AlarmResolvingSidebar.scss
+++ b/oobe/src/components/AlarmResolvingSidebar.scss
@@ -42,8 +42,11 @@
   }
 
   .padlock-logo {
-    height: 150px;
+    max-height: 20vh;
     width: auto;
+    object-fit: contain;
+    margin-top: 1rem !important;
+    margin-bottom: 1rem !important;
   }
 
   .spinner {


### PR DESCRIPTION
This commit has been done after a look on 7'' screen in which lock has been cropped:
https://github.com/user-attachments/assets/77e84e87-6b7f-4a6b-8626-02adf11dc1c0

