### PR TITLE
Fix bug in face recognition

### DIFF
--- a/oobe/src/api/APIClient.ts
+++ b/oobe/src/api/APIClient.ts
@@ -428,6 +428,9 @@ export class APIClient {
   }
 
   connectFaceRecognition(onUpdate: (update: FaceRecognitionUpdate[]) => void) {
+    if (this.faceWs) {
+      this.faceWs.close();
+    }
     this.faceWs = new WebSocket(
       `${this.config.apiUrl.toString().replace(/\/$/, "")}/ws`.replace(
         /^http/,

--- a/oobe/src/components/FaceRecognitionModal.tsx
+++ b/oobe/src/components/FaceRecognitionModal.tsx
@@ -25,23 +25,27 @@ const FaceRecognitionModal = ({
   const navigate = useNavigate();
 
   useEffect(() => {
+    let timer: ReturnType<typeof setTimeout>;
+
     if (show) {
+      setAuthenticated(false);
       apiClient.connectFaceRecognition(
         (updateData: FaceRecognitionUpdate[]) => {
           if (updateData.length && updateData[0].label === "face") {
             setAuthenticated(true);
-            const timer = setTimeout(() => {
+            timer = setTimeout(() => {
               onHide();
               navigate(url);
             }, 1000);
-            return () => clearTimeout(timer);
           }
         },
       );
-    } else {
-      apiClient.disconnectWebSocket();
-      setAuthenticated(false);
     }
+
+    return () => {
+      clearTimeout(timer);
+      apiClient.disconnectWebSocket("faceRecognition");
+    };
   }, [show, apiClient, onHide, url, navigate]);
 
   return (


### PR DESCRIPTION
The timeout set in the face recognition modal doesn't get cleared after exiting the modal. The callback, with navigate(url), gets called once per second even after the face recognition modal has disappeared.

Return correct cleanup function to useEffect.