### PR TITLE
Fix websocket opening and blister AI detection

### DIFF
--- a/oobe/src/api/APIClient.ts
+++ b/oobe/src/api/APIClient.ts
@@ -161,7 +161,7 @@ export class APIClient {
   }
 
   async getBlisterPackResult(imageFile: File): Promise<BlisterPackResult[]> {
-    const response = await this.axiosInstance.post<AIDetectionResult>(
+    const response = await this.axiosInstance.post<AIDetectionResultItem[]>(
       "/blister-pack-detect",
       imageFile,
       {
@@ -170,7 +170,7 @@ export class APIClient {
         },
       },
     );
-    return response.data.items.map(
+    return response.data.map(
       (item): BlisterPackResult => ({
         categoryId: item.category_id,
         bbox: item.bbox,

--- a/oobe/src/pages/IndustrialAlertManagement.tsx
+++ b/oobe/src/pages/IndustrialAlertManagement.tsx
@@ -142,6 +142,10 @@ const IndustrialAlertManagement = ({
 
   useEffect(() => {
     apiClient.connectIndustrial(handleUpdate);
+
+    return () => {
+      apiClient.disconnectWebSocket();
+    };
   }, [apiClient]);
 
   const closeWsConnection = () => {

--- a/oobe/src/pages/MedicalAlertManagement.tsx
+++ b/oobe/src/pages/MedicalAlertManagement.tsx
@@ -130,6 +130,10 @@ const MedicalAlertManagement = ({ apiClient }: MedicalAlertManagementProps) => {
 
   useEffect(() => {
     apiClient.connectMedical(handleUpdate);
+
+    return () => {
+      apiClient.disconnectWebSocket();
+    };
   }, [apiClient]);
 
   const closeWsConnection = () => {

--- a/oobe/src/pages/SmartAlertManagement.tsx
+++ b/oobe/src/pages/SmartAlertManagement.tsx
@@ -128,6 +128,10 @@ const SmartAlertManagement = ({ apiClient }: SmartAlertManagementProps) => {
 
   useEffect(() => {
     apiClient.connectSmart(handleUpdate);
+
+    return () => {
+      apiClient.disconnectWebSocket();
+    };
   }, [apiClient, handleUpdate]);
 
   const closeWsConnection = () => {


### PR DESCRIPTION
Has been noted through tests that blister detection gives error on image backend format even if the container is available. Furthermore, has been noted that the alert management going from the dashboard to the verticals does not open ws causing no data acquisition.