### PR TITLE
Add popup and change logic

### DIFF
--- a/oobe/src/components/AIErrorModal.scss
+++ b/oobe/src/components/AIErrorModal.scss
@@ -1,0 +1,35 @@
+.modal.show .modal-dialog.custom-modal {
+  max-width: 70vw !important;
+  width: 90vw !important;
+  margin: 0 auto !important;
+}
+
+.custom-modal {
+  max-width: 70vw !important;
+  width: 90vw !important;
+  margin: 0 auto !important;
+}
+
+.custom-modal .modal-content {
+  min-height: 500px;
+  height: auto;
+  border: 4px solid rgba(114, 114, 114, 0.2) !important;
+  border-radius: 24px !important;
+}
+
+.modal-body .text-bold {
+  font-weight: 700 !important;
+  font-weight: bold !important;
+}
+
+.modal-backdrop.show {
+  background-color: rgba(0, 0, 0, 0.1) !important;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  opacity: 1 !important;
+}
+
+.modal-backdrop.fade {
+  transition: opacity 0.15s linear, backdrop-filter 0.15s linear;
+  -webkit-transition: opacity 0.15s linear, -webkit-backdrop-filter 0.15s linear;
+} 

--- a/oobe/src/components/AIErrorModal.scss
+++ b/oobe/src/components/AIErrorModal.scss
@@ -30,6 +30,10 @@
 }
 
 .modal-backdrop.fade {
-  transition: opacity 0.15s linear, backdrop-filter 0.15s linear;
-  -webkit-transition: opacity 0.15s linear, -webkit-backdrop-filter 0.15s linear;
-} 
+  transition:
+    opacity 0.15s linear,
+    backdrop-filter 0.15s linear;
+  -webkit-transition:
+    opacity 0.15s linear,
+    -webkit-backdrop-filter 0.15s linear;
+}

--- a/oobe/src/components/AIErrorModal.scss
+++ b/oobe/src/components/AIErrorModal.scss
@@ -23,17 +23,17 @@
 }
 
 .modal-backdrop.show {
-  background-color: rgba(0, 0, 0, 0.1) !important;
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  background-color: rgba(0, 0, 0, 0.4) !important;
+  background-image: radial-gradient(
+    circle,
+    rgba(255, 255, 255, 0.1) 1px,
+    transparent 1px
+  );
+  background-size: 3px 3px;
   opacity: 1 !important;
 }
 
 .modal-backdrop.fade {
-  transition:
-    opacity 0.15s linear,
-    backdrop-filter 0.15s linear;
-  -webkit-transition:
-    opacity 0.15s linear,
-    -webkit-backdrop-filter 0.15s linear;
+  transition: none !important;
+  -webkit-transition: none !important;
 }

--- a/oobe/src/components/AIErrorModal.tsx
+++ b/oobe/src/components/AIErrorModal.tsx
@@ -1,5 +1,5 @@
 import { Modal, Button } from "react-bootstrap";
-import { useState , type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import "./AIErrorModal.scss";
 
 interface AIErrorModalProps {
@@ -10,18 +10,26 @@ interface AIErrorModalProps {
   message?: ReactNode;
 }
 
-const AIErrorModal = ({ 
-  show, 
-  onHide, 
-  onContinue, 
+const AIErrorModal = ({
+  show,
+  onHide,
+  onContinue,
   onExit,
   message = (
     <>
-      <strong>No AI model</strong> is currently deployed on this device.<br />
-      To run this application, deploy a model from your <strong>Clea</strong> account.<br />
-      If you have already deployed the model click '<strong>Check again</strong>' to verify.
+      <strong>No AI model</strong> is currently deployed on this device.
+      <br />
+      To run this application, deploy a model from your <strong>
+        Clea
+      </strong>{" "}
+      account.
+      <br />
+      If you have already deployed the model click '<strong>Check again</strong>
+      ' to verify.
     </>
-  )}: AIErrorModalProps) => {  const [loading, setLoading] = useState(false);
+  ),
+}: AIErrorModalProps) => {
+  const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const handleContinue = async () => {
@@ -35,65 +43,88 @@ const AIErrorModal = ({
       } else {
         setErrorMsg("No model detected. Please deploy a model and try again");
       }
-    } catch (e) {
+    } catch {
       setLoading(false);
       setErrorMsg("No model detected. Please deploy a model and try again");
     }
   };
 
   return (
-    <Modal 
-      show={show} 
-      onHide={onHide} 
+    <Modal
+      show={show}
+      onHide={onHide}
       centered
       backdrop="static"
       keyboard={false}
       dialogClassName="custom-modal"
       contentClassName="border border-grey rounded-4 overflow-hidden"
     >
-      <Modal.Header 
-        className="border-0" 
-        style={{ backgroundColor: '#000', paddingBottom: '0.5rem' }}
-      >
-      </Modal.Header>
+      <Modal.Header
+        className="border-0"
+        style={{ backgroundColor: "#000", paddingBottom: "0.5rem" }}
+      ></Modal.Header>
 
-      <Modal.Body 
-        className="px-5 py-4 text-center border-0 d-flex flex-column justify-content-center" 
-        style={{ backgroundColor: '#000', color: '#fff' }}
+      <Modal.Body
+        className="px-5 py-4 text-center border-0 d-flex flex-column justify-content-center"
+        style={{ backgroundColor: "#000", color: "#fff" }}
       >
-        <h2 className="fw-bold mb-3" style={{ fontSize: '2.5rem' }}>Attention</h2>
-        
-        <p className="mb-4" style={{ fontSize: '2rem', opacity: 0.9, lineHeight: '1.6' }}>
+        <h2 className="fw-bold mb-3" style={{ fontSize: "2.5rem" }}>
+          Attention
+        </h2>
+
+        <p
+          className="mb-4"
+          style={{ fontSize: "2rem", opacity: 0.9, lineHeight: "1.6" }}
+        >
           {message}
         </p>
-        
+
         {errorMsg && (
-          <div 
-            className="mb-4 fw-bold" 
-            style={{ color: '#ff0000', fontSize: '1.4rem', textShadow: '0 0 10px rgba(255,0,0,0.3)' }}
+          <div
+            className="mb-4 fw-bold"
+            style={{
+              color: "#ff0000",
+              fontSize: "1.4rem",
+              textShadow: "0 0 10px rgba(255,0,0,0.3)",
+            }}
           >
             {errorMsg}
           </div>
         )}
 
         <div className="d-flex justify-content-center gap-3">
-          <Button 
-            variant="primary" 
-            onClick={handleContinue} 
+          <Button
+            variant="primary"
+            onClick={handleContinue}
             disabled={loading}
             className="px-5 py-3 fw-bold"
-            style={{ borderRadius: '15px', backgroundColor: '#fff', color: '#000', border: 'none' }}
+            style={{
+              borderRadius: "15px",
+              backgroundColor: "#fff",
+              color: "#000",
+              border: "none",
+            }}
           >
-            <h2 className="mb-1" style={{ fontSize: '1.7rem', fontWeight: '800' }}>Check again</h2>
+            <h2
+              className="mb-1"
+              style={{ fontSize: "1.7rem", fontWeight: "800" }}
+            >
+              Check again
+            </h2>
           </Button>
-          <Button 
-            variant="outline-light" 
-            onClick={onExit || onHide} 
+          <Button
+            variant="outline-light"
+            onClick={onExit || onHide}
             disabled={loading}
             className="px-5 py-3 fw-bold"
-            style={{ borderRadius: '15px', border: '2px solid #fff' }}
+            style={{ borderRadius: "15px", border: "2px solid #fff" }}
           >
-            <h2 className="mb-1" style={{ fontSize: '1.7rem', fontWeight: '800',color: '#fff' }}>Exit</h2>
+            <h2
+              className="mb-1"
+              style={{ fontSize: "1.7rem", fontWeight: "800", color: "#fff" }}
+            >
+              Exit
+            </h2>
           </Button>
         </div>
       </Modal.Body>

--- a/oobe/src/components/AIErrorModal.tsx
+++ b/oobe/src/components/AIErrorModal.tsx
@@ -1,21 +1,27 @@
 import { Modal, Button } from "react-bootstrap";
-import { useState } from "react";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faX } from "@fortawesome/free-solid-svg-icons";
+import { useState , type ReactNode } from "react";
+import "./AIErrorModal.scss";
 
 interface AIErrorModalProps {
   show: boolean;
   onHide: () => void;
   onContinue: () => Promise<boolean>;
-  message?: string;
+  onExit?: () => void;
+  message?: ReactNode;
 }
 
 const AIErrorModal = ({ 
   show, 
   onHide, 
   onContinue, 
-  message = "if you see this pop-up, please check that the AI service is available or deployed." 
-}: AIErrorModalProps) => {  const [loading, setLoading] = useState(false);
+  onExit,
+  message = (
+    <>
+      <strong>No AI model</strong> is currently deployed on this device.<br />
+      To run this application, deploy a model from your <strong>Clea</strong> account.<br />
+      If you have already deployed the model click '<strong>Check again</strong>' to verify.
+    </>
+  )}: AIErrorModalProps) => {  const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const handleContinue = async () => {
@@ -27,11 +33,11 @@ const AIErrorModal = ({
       if (ok) {
         onHide();
       } else {
-        setErrorMsg("Still unavailable. Please try again.");
+        setErrorMsg("No model detected. Please deploy a model and try again");
       }
     } catch (e) {
       setLoading(false);
-      setErrorMsg("Still unavailable. Please try again.");
+      setErrorMsg("No model detected. Please deploy a model and try again");
     }
   };
 
@@ -39,30 +45,25 @@ const AIErrorModal = ({
     <Modal 
       show={show} 
       onHide={onHide} 
-      centered 
-      backdrop="static" 
-      contentClassName="border border-white rounded-4 overflow-hidden"
+      centered
+      backdrop="static"
+      keyboard={false}
+      dialogClassName="custom-modal"
+      contentClassName="border border-grey rounded-4 overflow-hidden"
     >
       <Modal.Header 
-        className="flex-row-reverse border-0" 
+        className="border-0" 
         style={{ backgroundColor: '#000', paddingBottom: '0.5rem' }}
       >
-        <Modal.Title className="w-100 d-flex justify-content-end">
-          <Button variant="link" className="close-icon-button p-0 text-white shadow-none" onClick={onHide}>
-            <FontAwesomeIcon icon={faX} size="sm" style={{ color: '#fff' }} />
-          </Button>
-        </Modal.Title>
       </Modal.Header>
 
       <Modal.Body 
-        className="px-4 pb-5 pt-0 text-center border-0" 
+        className="px-5 py-4 text-center border-0 d-flex flex-column justify-content-center" 
         style={{ backgroundColor: '#000', color: '#fff' }}
       >
-        {}
-        <h2 className="fw-bold mb-3" style={{ fontSize: '2rem' }}>Welcome</h2>
+        <h2 className="fw-bold mb-3" style={{ fontSize: '2.5rem' }}>Attention</h2>
         
-        {}
-        <p className="mb-4" style={{ fontSize: '1.7rem', opacity: 0.9 }}>
+        <p className="mb-4" style={{ fontSize: '2rem', opacity: 0.9, lineHeight: '1.6' }}>
           {message}
         </p>
         
@@ -75,13 +76,13 @@ const AIErrorModal = ({
           </div>
         )}
 
-        <div>
+        <div className="d-flex justify-content-center gap-3">
           <Button 
             variant="primary" 
             onClick={handleContinue} 
             disabled={loading}
-            className="px-5 py-2 fw-bold"
-            style={{ borderRadius: '50px', backgroundColor: '#007bff', border: 'none' }}
+            className="px-5 py-3 fw-bold"
+            style={{ borderRadius: '15px', backgroundColor: '#fff', color: '#000', border: 'none' }}
           >
             {loading ? (
               <span className="d-flex align-items-center gap-2">
@@ -89,8 +90,17 @@ const AIErrorModal = ({
                 Checking...
               </span>
             ) : (
-              <h2 className="fw-bold mb-1" style={{ fontSize: '1.4rem' }}>Continue with analysis</h2>
+              <h2 className="mb-1" style={{ fontSize: '1.7rem', fontWeight: '800' }}>Check again</h2>
             )}
+          </Button>
+          <Button 
+            variant="outline-light" 
+            onClick={onExit || onHide} 
+            disabled={loading}
+            className="px-5 py-3 fw-bold"
+            style={{ borderRadius: '15px', border: '2px solid #fff' }}
+          >
+            <h2 className="mb-1" style={{ fontSize: '1.7rem', fontWeight: '800',color: '#fff' }}>Exit</h2>
           </Button>
         </div>
       </Modal.Body>

--- a/oobe/src/components/AIErrorModal.tsx
+++ b/oobe/src/components/AIErrorModal.tsx
@@ -84,14 +84,7 @@ const AIErrorModal = ({
             className="px-5 py-3 fw-bold"
             style={{ borderRadius: '15px', backgroundColor: '#fff', color: '#000', border: 'none' }}
           >
-            {loading ? (
-              <span className="d-flex align-items-center gap-2">
-                <span className="spinner-border spinner-border-sm" role="status" />
-                Checking...
-              </span>
-            ) : (
-              <h2 className="mb-1" style={{ fontSize: '1.7rem', fontWeight: '800' }}>Check again</h2>
-            )}
+            <h2 className="mb-1" style={{ fontSize: '1.7rem', fontWeight: '800' }}>Check again</h2>
           </Button>
           <Button 
             variant="outline-light" 

--- a/oobe/src/components/AIErrorModal.tsx
+++ b/oobe/src/components/AIErrorModal.tsx
@@ -1,0 +1,101 @@
+import { Modal, Button } from "react-bootstrap";
+import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faX } from "@fortawesome/free-solid-svg-icons";
+
+interface AIErrorModalProps {
+  show: boolean;
+  onHide: () => void;
+  onContinue: () => Promise<boolean>;
+  message?: string;
+}
+
+const AIErrorModal = ({ 
+  show, 
+  onHide, 
+  onContinue, 
+  message = "if you see this pop-up, please check that the AI service is available or deployed." 
+}: AIErrorModalProps) => {  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const handleContinue = async () => {
+    setErrorMsg(null);
+    setLoading(true);
+    try {
+      const ok = await onContinue();
+      setLoading(false);
+      if (ok) {
+        onHide();
+      } else {
+        setErrorMsg("Still unavailable. Please try again.");
+      }
+    } catch (e) {
+      setLoading(false);
+      setErrorMsg("Still unavailable. Please try again.");
+    }
+  };
+
+  return (
+    <Modal 
+      show={show} 
+      onHide={onHide} 
+      centered 
+      backdrop="static" 
+      contentClassName="border border-white rounded-4 overflow-hidden"
+    >
+      <Modal.Header 
+        className="flex-row-reverse border-0" 
+        style={{ backgroundColor: '#000', paddingBottom: '0.5rem' }}
+      >
+        <Modal.Title className="w-100 d-flex justify-content-end">
+          <Button variant="link" className="close-icon-button p-0 text-white shadow-none" onClick={onHide}>
+            <FontAwesomeIcon icon={faX} size="sm" style={{ color: '#fff' }} />
+          </Button>
+        </Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body 
+        className="px-4 pb-5 pt-0 text-center border-0" 
+        style={{ backgroundColor: '#000', color: '#fff' }}
+      >
+        {}
+        <h2 className="fw-bold mb-3" style={{ fontSize: '2rem' }}>Welcome</h2>
+        
+        {}
+        <p className="mb-4" style={{ fontSize: '1.7rem', opacity: 0.9 }}>
+          {message}
+        </p>
+        
+        {errorMsg && (
+          <div 
+            className="mb-4 fw-bold" 
+            style={{ color: '#ff0000', fontSize: '1.4rem', textShadow: '0 0 10px rgba(255,0,0,0.3)' }}
+          >
+            {errorMsg}
+          </div>
+        )}
+
+        <div>
+          <Button 
+            variant="primary" 
+            onClick={handleContinue} 
+            disabled={loading}
+            className="px-5 py-2 fw-bold"
+            style={{ borderRadius: '50px', backgroundColor: '#007bff', border: 'none' }}
+          >
+            {loading ? (
+              <span className="d-flex align-items-center gap-2">
+                <span className="spinner-border spinner-border-sm" role="status" />
+                Checking...
+              </span>
+            ) : (
+              <h2 className="fw-bold mb-1" style={{ fontSize: '1.4rem' }}>Continue with analysis</h2>
+            )}
+          </Button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default AIErrorModal;

--- a/oobe/src/i18n/langs/en.json
+++ b/oobe/src/i18n/langs/en.json
@@ -269,9 +269,6 @@
   "faceRecognitionModal.tenantRecognized": {
     "defaultMessage": "Tenant successfully recognized."
   },
-  "imageFormatError": {
-    "defaultMessage": "Backend rejected the image format."
-  },
   "industrialAlertManagement.dischargePressure": {
     "defaultMessage": "DISCHARGE PRESSURE"
   },

--- a/oobe/src/i18n/langs/it.json
+++ b/oobe/src/i18n/langs/it.json
@@ -257,9 +257,6 @@
   "electricityMeter.title": {
     "defaultMessage": "Electricity Meter"
   },
-  "imageFormatError": {
-    "defaultMessage": "Backend rejected the image format."
-  },
   "faceRecognitionModal.authenticatedUser": {
     "defaultMessage": "Authorization confirmed"
   },

--- a/oobe/src/pages/CrowdAndFallDetection.tsx
+++ b/oobe/src/pages/CrowdAndFallDetection.tsx
@@ -1,10 +1,11 @@
-import { Container, Image, Button, Alert } from "react-bootstrap";
+import { Container, Image, Button } from "react-bootstrap";
 import { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faX, faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { FormattedMessage, defineMessages } from "react-intl";
 import ImageCarousel from "./ImageCarousel";
+import AIErrorModal from "../components/AIErrorModal";
 import { APIClient } from "../api/APIClient";
 import {
   logo,
@@ -126,7 +127,6 @@ const urlToFile = async (url: string): Promise<File> => {
 
 const CrowdAndFallDetection = ({ apiClient }: CrowdAndFallDetectionProps) => {
   const [results, setResults] = useState<PersonResult[]>([]);
-  const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<"greeting" | "analysis" | "result">(
     "greeting",
   );
@@ -139,6 +139,7 @@ const CrowdAndFallDetection = ({ apiClient }: CrowdAndFallDetectionProps) => {
     left: 0,
     top: 0,
   });
+  const [showAIErrorModal, setShowAIErrorModal] = useState(false);
 
   const imageRef = useRef<HTMLImageElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -198,8 +199,8 @@ const CrowdAndFallDetection = ({ apiClient }: CrowdAndFallDetectionProps) => {
         setAnalysisTime(new Date());
         setStatus("result");
       } catch {
-        setError("Error");
-        setStatus("greeting");
+        setShowAIErrorModal(true);
+        // keep status as 'analysis' so the modal overlays the spinner and user can retry
       }
     };
     processImage();
@@ -401,16 +402,27 @@ const CrowdAndFallDetection = ({ apiClient }: CrowdAndFallDetectionProps) => {
           </div>
         </div>
       )}
-      {error && (
-        <Alert
-          variant="danger"
-          className="position-fixed bottom-0 start-0 m-3 z-3 shadow-lg border-0 rounded-3"
-          onClose={() => setError(null)}
-          dismissible
-        >
-          <FormattedMessage {...messages.errorMsg} />
-        </Alert>
-      )}
+      <AIErrorModal
+        show={showAIErrorModal}
+        onHide={() => {
+          setShowAIErrorModal(false);
+          setStatus("result");
+        }}
+        onContinue={async () => {
+          try {
+            setResults([]);
+            const file = await urlToFile(currentImage);
+            const data = await apiClient.getPersonResult(file);
+            setResults(data || []);
+            setAnalysisTime(new Date());
+            setStatus("result");
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }}
+        message="if you see this pop-up, please check that the AI service is available or deployed"
+      />
     </Container>
   );
 };

--- a/oobe/src/pages/CrowdAndFallDetection.tsx
+++ b/oobe/src/pages/CrowdAndFallDetection.tsx
@@ -420,7 +420,7 @@ const CrowdAndFallDetection = ({ apiClient }: CrowdAndFallDetectionProps) => {
             setAnalysisTime(new Date());
             setStatus("result");
             return true;
-          } catch (e) {
+          } catch {
             return false;
           }
         }}

--- a/oobe/src/pages/CrowdAndFallDetection.tsx
+++ b/oobe/src/pages/CrowdAndFallDetection.tsx
@@ -325,7 +325,7 @@ const CrowdAndFallDetection = ({ apiClient }: CrowdAndFallDetectionProps) => {
             </div>
 
             <div className="flex-grow-1 overflow-auto pe-2 custom-scrollbar mb-3">
-              {status === "analysis" ? (
+              {status === "analysis" && !showAIErrorModal ? (
                 <div className="d-flex align-items-center gap-3 text-info p-4 bg-dark bg-opacity-50 rounded-4 border border-info border-opacity-25">
                   <div className="spinner-border spinner-border-sm" />
                   <FormattedMessage {...messages.scanningMessage} />

--- a/oobe/src/pages/CrowdAndFallDetection.tsx
+++ b/oobe/src/pages/CrowdAndFallDetection.tsx
@@ -406,7 +406,10 @@ const CrowdAndFallDetection = ({ apiClient }: CrowdAndFallDetectionProps) => {
         show={showAIErrorModal}
         onHide={() => {
           setShowAIErrorModal(false);
-          setStatus("result");
+        }}
+        onExit={() => {
+          setShowAIErrorModal(false);
+          navigate("/smart-building");
         }}
         onContinue={async () => {
           try {
@@ -421,7 +424,6 @@ const CrowdAndFallDetection = ({ apiClient }: CrowdAndFallDetectionProps) => {
             return false;
           }
         }}
-        message="if you see this pop-up, please check that the AI service is available or deployed"
       />
     </Container>
   );

--- a/oobe/src/pages/ImageCarousel.tsx
+++ b/oobe/src/pages/ImageCarousel.tsx
@@ -53,8 +53,8 @@ const ImageCarousel = ({
                 : "border-secondary opacity-50"
             }`}
             style={{
-              width: "110px",
-              height: "70px",
+              width: "150px",
+              height: "150px",
               transition: "all 0.2s ease-in-out",
             }}
             onClick={() => onSelect(img)}

--- a/oobe/src/pages/QualityInspection.tsx
+++ b/oobe/src/pages/QualityInspection.tsx
@@ -166,7 +166,7 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
               setStatus("result");
             }
             return true;
-          } catch (e) {
+          } catch {
             return false;
           }
         }}

--- a/oobe/src/pages/QualityInspection.tsx
+++ b/oobe/src/pages/QualityInspection.tsx
@@ -158,7 +158,10 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
         show={showAIErrorModal}
         onHide={() => {
           setShowAIErrorModal(false);
-          setStatus("result");
+        }}
+        onExit={() => {
+          setShowAIErrorModal(false);
+          navigate("/industrial");
         }}
         onContinue={async () => {
           try {
@@ -166,15 +169,16 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
             setInferenceTime(null);
             const file = await urlToFile(currentImage);
             const data = await apiClient.getDefectResult(file, analysisMode);
-            setDefectResults(data.results || []);
-            setInferenceTime(data.inferenceTime || null);
-            setStatus("result");
+            if (data) {
+              setDefectResults(data.results || []);
+              setInferenceTime(data.inferenceTime || null);
+              setStatus("result");
+            }
             return true;
           } catch (e) {
             return false;
           }
         }}
-        message="if you see this pop-up, please check that the AI service is available or deployed"
       />
 
       <div

--- a/oobe/src/pages/QualityInspection.tsx
+++ b/oobe/src/pages/QualityInspection.tsx
@@ -1,4 +1,4 @@
-import { Container, Image, Button, Alert } from "react-bootstrap";
+import { Container, Image, Button } from "react-bootstrap";
 import { logo } from "../assets/images";
 import "./QualityInspection.scss";
 import { useNavigate } from "react-router-dom";
@@ -20,6 +20,7 @@ import {
 } from "../assets/images";
 import { APIClient, type AnalysisMode } from "../api/APIClient";
 import ImageCarousel from "./ImageCarousel";
+import AIErrorModal from "../components/AIErrorModal";
 
 const MISSING_HOLE_COLOR = "#FF0000";
 const SHORT_CIRCUIT_COLOR = "#FFC107";
@@ -65,10 +66,10 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
   const [defectResults, setDefectResults] = useState<DefectResult[]>([]);
   const [analysisMode, setAnalysisMode] = useState<AnalysisMode>("cpu");
   const [inferenceTime, setInferenceTime] = useState<number | null>(null);
-  const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState("greeting");
   const [currentImage, setCurrentImage] = useState(pcbMissingHole00);
   const [scale, setScale] = useState({ x: 1, y: 1 });
+  const [showAIErrorModal, setShowAIErrorModal] = useState(false);
 
   const imageRef = useRef<HTMLImageElement>(null);
   const navigate = useNavigate();
@@ -90,14 +91,14 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
   }, []);
 
   useEffect(() => {
-    if (status !== "analysis") return;
+    if (status !== "analysis" || showAIErrorModal) return;
 
     const timer = setTimeout(() => {
-      if (status === "analysis") setStatus("result");
+      if (status === "analysis" && !showAIErrorModal) setStatus("result");
     }, 2000);
 
     return () => clearTimeout(timer);
-  }, [status, currentImage]);
+  }, [status, currentImage, showAIErrorModal]);
 
   useEffect(() => {
     if (status !== "analysis") return;
@@ -110,12 +111,7 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
         setDefectResults(data.results);
         setInferenceTime(data.inferenceTime);
       } catch {
-        setError(
-          intl.formatMessage({
-            id: "imageFormatError",
-            defaultMessage: "Backend rejected the image format.",
-          }),
-        );
+        setShowAIErrorModal(true);
       }
     };
 
@@ -158,16 +154,28 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
         <div style={{ width: "24px" }}></div>
       </div>
 
-      {error && (
-        <Alert
-          onClose={() => setError(null)}
-          dismissible
-          variant="danger"
-          className="mb-3"
-        >
-          {error}
-        </Alert>
-      )}
+      <AIErrorModal
+        show={showAIErrorModal}
+        onHide={() => {
+          setShowAIErrorModal(false);
+          setStatus("result");
+        }}
+        onContinue={async () => {
+          try {
+            setDefectResults([]);
+            setInferenceTime(null);
+            const file = await urlToFile(currentImage);
+            const data = await apiClient.getDefectResult(file, analysisMode);
+            setDefectResults(data.results || []);
+            setInferenceTime(data.inferenceTime || null);
+            setStatus("result");
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }}
+        message="if you see this pop-up, please check that the AI service is available or deployed"
+      />
 
       <div
         className={

--- a/oobe/src/pages/QualityInspection.tsx
+++ b/oobe/src/pages/QualityInspection.tsx
@@ -91,16 +91,6 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
   }, []);
 
   useEffect(() => {
-    if (status !== "analysis" || showAIErrorModal) return;
-
-    const timer = setTimeout(() => {
-      if (status === "analysis" && !showAIErrorModal) setStatus("result");
-    }, 2000);
-
-    return () => clearTimeout(timer);
-  }, [status, currentImage, showAIErrorModal]);
-
-  useEffect(() => {
     if (status !== "analysis") return;
     const processImage = async () => {
       try {
@@ -110,6 +100,7 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
         const data = await apiClient.getDefectResult(file, analysisMode);
         setDefectResults(data.results);
         setInferenceTime(data.inferenceTime);
+        setStatus("result");
       } catch {
         setShowAIErrorModal(true);
       }
@@ -245,6 +236,7 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
                 onSelect={(img) => {
                   setCurrentImage(img);
                   setDefectResults([]);
+                  setStatus("idle");
                 }}
               />
             </div>
@@ -252,16 +244,16 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
 
           <div className="col-md-5 d-flex flex-column align-items-center justify-content-center">
             <div className="mb-5 mt-5 text-center">
-              {status === "analysis" && (
+              {status === "analysis" && !showAIErrorModal && (
                 <div className="spinner-border mb-5 spinner" role="status" />
               )}
               <h3 className="fw-bold d-flex flex-column align-items-start text-start">
-                {status === "analysis" ? (
+                {status === "analysis" && !showAIErrorModal ? (
                   <FormattedMessage
                     id="qualityInspection.analyseMessage"
                     defaultMessage="Scanning in progress..."
                   />
-                ) : (
+                ) : status === "result" ? (
                   <div className="d-flex flex-column align-items-start gap-1">
                     <FormattedMessage
                       id="qualityInspection.anomaliesDetectedMessage"
@@ -304,7 +296,7 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
                       />
                     </div>
                   </div>
-                )}
+                ) : null}
               </h3>
             </div>
 
@@ -349,8 +341,7 @@ const QualityInspection = ({ apiClient }: QualityInspectionProps) => {
             variant="light"
             className="greeting-button py-2 px-5 fw-bold"
             onClick={() => {
-              setStatus("analysis");
-              setAnalysisMode("cpu");
+              setStatus("idle");
             }}
           >
             <FormattedMessage

--- a/oobe/src/pages/SampleIntegrityCheck.tsx
+++ b/oobe/src/pages/SampleIntegrityCheck.tsx
@@ -1,4 +1,4 @@
-import { Container, Image, Button, Alert } from "react-bootstrap";
+import { Container, Image, Button } from "react-bootstrap";
 import { logo } from "../assets/images";
 import "./SampleIntegrityCheck.scss";
 import { useNavigate } from "react-router-dom";
@@ -25,6 +25,7 @@ import {
 } from "../assets/images";
 import { APIClient } from "../api/APIClient";
 import ImageCarousel from "./ImageCarousel";
+import AIErrorModal from "../components/AIErrorModal";
 
 const EMPTY_BLISTER_COLOR = "#FF0000";
 const FULL_BLISTER_COLOR = "#FFC107";
@@ -52,10 +53,10 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
   const [blisterPackResults, setBlisterPackResults] = useState<
     BlisterPackResult[]
   >([]);
-  const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState("greeting");
   const [currentImage, setCurrentImage] = useState(blisterPackEmpty00);
   const [scale, setScale] = useState({ x: 1, y: 1 });
+  const [showAIErrorModal, setShowAIErrorModal] = useState(false);
 
   const imageRef = useRef<HTMLImageElement>(null);
   const navigate = useNavigate();
@@ -113,12 +114,7 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
         const data = await apiClient.getBlisterPackResult(file);
         setBlisterPackResults(data);
       } catch {
-        setError(
-          intl.formatMessage({
-            id: "imageFormatError",
-            defaultMessage: "Backend rejected the image format.",
-          }),
-        );
+        setShowAIErrorModal(true);
       }
     };
 
@@ -161,16 +157,25 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
         <div style={{ width: "24px" }}></div>
       </div>
 
-      {error && (
-        <Alert
-          onClose={() => setError(null)}
-          dismissible
-          variant="danger"
-          className="mb-3"
-        >
-          {error}
-        </Alert>
-      )}
+      <AIErrorModal
+        show={showAIErrorModal}
+        onHide={() => setShowAIErrorModal(false)}
+        onContinue={async () => {
+          try {
+            setBlisterPackResults([]);
+            const file = await urlToFile(currentImage);
+            const data = await apiClient.getBlisterPackResult(file);
+            if (data && data.length) {
+              setBlisterPackResults(data);
+            }
+            setStatus("result");
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }}
+        message="if you see this pop-up, please check that the AI service is available or deployed"
+      />
 
       <div
         className={

--- a/oobe/src/pages/SampleIntegrityCheck.tsx
+++ b/oobe/src/pages/SampleIntegrityCheck.tsx
@@ -97,22 +97,13 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
 
   useEffect(() => {
     if (status !== "analysis") return;
-
-    const timer = setTimeout(() => {
-      if (status === "analysis") setStatus("result");
-    }, 5000);
-
-    return () => clearTimeout(timer);
-  }, [status, currentImage]);
-
-  useEffect(() => {
-    if (status !== "analysis") return;
     const processImage = async () => {
       try {
         setBlisterPackResults([]);
         const file = await urlToFile(currentImage);
         const data = await apiClient.getBlisterPackResult(file);
         setBlisterPackResults(data);
+        setStatus("result");
       } catch {
         setShowAIErrorModal(true);
       }
@@ -254,16 +245,16 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
 
           <div className="col-md-5 d-flex flex-column align-items-center justify-content-center">
             <div className="mb-5 mt-5 text-center">
-              {status === "analysis" && (
+              {status === "analysis" && !showAIErrorModal && (
                 <div className="spinner-border mb-5 spinner" role="status" />
               )}
               <h3 className="fw-bold d-flex flex-column align-items-start text-start">
-                {status === "analysis" ? (
+                {status === "analysis" && !showAIErrorModal ? (
                   <FormattedMessage
                     id="SampleIntegrityCheck.analyseMessage"
                     defaultMessage="Scanning in progress..."
                   />
-                ) : (
+                ) : status === "result" ? (
                   <div className="d-flex flex-column align-items-start gap-1">
                     <FormattedMessage
                       id="SampleIntegrityCheck.anomaliesDetectedMessage"
@@ -291,7 +282,7 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
                       />
                     </div>
                   </div>
-                )}{" "}
+                ) : null}{" "}
               </h3>
             </div>
 

--- a/oobe/src/pages/SampleIntegrityCheck.tsx
+++ b/oobe/src/pages/SampleIntegrityCheck.tsx
@@ -167,7 +167,7 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
               setStatus("result");
             }
             return true;
-          } catch (e) {
+          } catch {
             return false;
           }
         }}

--- a/oobe/src/pages/SampleIntegrityCheck.tsx
+++ b/oobe/src/pages/SampleIntegrityCheck.tsx
@@ -159,7 +159,13 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
 
       <AIErrorModal
         show={showAIErrorModal}
-        onHide={() => setShowAIErrorModal(false)}
+        onHide={() => {
+          setShowAIErrorModal(false);
+        }}
+        onExit={() => {
+          setShowAIErrorModal(false);
+          navigate("/medical");
+        }}
         onContinue={async () => {
           try {
             setBlisterPackResults([]);
@@ -167,14 +173,13 @@ const SampleIntegrityCheck = ({ apiClient }: SampleIntegrityCheckProps) => {
             const data = await apiClient.getBlisterPackResult(file);
             if (data && data.length) {
               setBlisterPackResults(data);
+              setStatus("result");
             }
-            setStatus("result");
             return true;
           } catch (e) {
             return false;
           }
         }}
-        message="if you see this pop-up, please check that the AI service is available or deployed"
       />
 
       <div


### PR DESCRIPTION
In this pull request has been changed few things to make sure that users have better experience on opening the app. 
The first thing changed is a popup that appears into the AI analysis menus; in particular, if the dedicated container is not available the popup appears allowing, through the exit button, to return in the previous menu; if check button is pressed, the popup reads if the AI container is present, if not it gives error and show a message. 
This has been done for all verticals. PCB defect detection before changes started the analysis when entered in the menu; now, after entering the menu we have to select cpu or npu analysis with the same logic used before for AI container detection.
Another change done is  the timing on loading gear which has been reduced to the time given by AI analysis.